### PR TITLE
Voice XP Refactor, Level Display Refactor

### DIFF
--- a/src/com/somefriggnidiot/discord/commands/ProfileCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/ProfileCommand.java
@@ -42,7 +42,8 @@ public class ProfileCommand extends Command {
 
       if (event.getMessage().getMentionedUsers().size() == 0) {
          dbu = DatabaseUserUtil.getUser(event.getAuthor().getIdLong());
-         level = dbu.getLevel() == null ? "0" : dbu.getLevel().toString();
+         level = new DatabaseUserUtil(event.getAuthor().getIdLong())
+             .getLevel(event.getGuild().getIdLong()).toString();
          xp = dbu.getXpMap().get(event.getGuild().getIdLong()) == null ? 0 : dbu.getXpMap().get
              (event.getGuild().getIdLong());
          nextXp = XpUtil.getXpThresholdForLevel(Integer.valueOf(level)+1);
@@ -69,7 +70,8 @@ public class ProfileCommand extends Command {
       } else {
          User user = event.getMessage().getMentionedUsers().get(0);
          dbu = DatabaseUserUtil.getUser(user.getIdLong());
-         level = dbu.getLevel() == null ? "0" : dbu.getLevel().toString();
+         level = new DatabaseUserUtil(user.getIdLong())
+             .getLevel(event.getGuild().getIdLong()).toString();
          xp = dbu.getXpMap().get(event.getGuild().getIdLong()) == null ? 0 : dbu.getXpMap().get
              (event.getGuild().getIdLong());
          nextXp = XpUtil.getXpThresholdForLevel(Integer.valueOf(level)+1);

--- a/src/com/somefriggnidiot/discord/commands/functionalities/raffle/RaffleCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/functionalities/raffle/RaffleCommand.java
@@ -14,5 +14,16 @@ public class RaffleCommand extends Command {
       String message = event.getMessage().getContentDisplay();
 
       //TODO use switch, combine all raffle commands into one.
+
+      //If first arg is number, return information about raffle with that id
+
+      /*
+      USAGES
+      1. Display information about a raffle. (Arg provided is a number.)
+      2. List raffles (No args)
+      3. CREATE - similar to existing params for creating raffle.
+      4. DRAW - similar to existing params for drawing raffle.
+      5. CLOSE - closes a raffle.
+       */
    }
 }

--- a/src/com/somefriggnidiot/discord/commands/functionalities/tokens/ResetAllTokensCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/functionalities/tokens/ResetAllTokensCommand.java
@@ -1,0 +1,46 @@
+package com.somefriggnidiot.discord.commands.functionalities.tokens;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.somefriggnidiot.discord.data_access.util.DatabaseUserUtil;
+import java.util.List;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.Member;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResetAllTokensCommand extends Command {
+
+   private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+   public ResetAllTokensCommand() {
+      this.name = "resetalltokens";
+      this.aliases = new String[]{};
+      this.arguments = "";
+      this.ownerCommand = true;
+      this.category = new Category("Tokens");
+      this.help = "Resets tokens for all users in the server.";
+      this.botPermissions = new Permission[]{Permission.MESSAGE_WRITE, Permission.MESSAGE_READ};
+      this.guildOnly = true;
+      this.cooldown = 1;
+      this.cooldownScope = CooldownScope.USER_GUILD;
+   }
+
+   @Override
+   protected void execute(final CommandEvent event) {
+      Long guildId = event.getGuild().getIdLong();
+      List<Member> guildMembers = event.getGuild().getMembers();
+
+      try {
+         guildMembers.forEach(member ->
+             new DatabaseUserUtil(member.getUser().getIdLong())
+                 .setTokens(guildId, 0)
+         );
+
+         event.reply("Successfully removed tokens from all users.");
+      } catch(Exception e) {
+         event.reply("There was an error removing user tokens.");
+      }
+
+   }
+}

--- a/src/com/somefriggnidiot/discord/commands/functionalities/xp/moderation/AdjustXpCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/functionalities/xp/moderation/AdjustXpCommand.java
@@ -48,7 +48,7 @@ public class AdjustXpCommand extends Command {
       Integer adjustedLevel = XpUtil.getLevelForXp(adjustedXp);
 
       DatabaseUserUtil.setXp(guildId, memberId, adjustedXp);
-      DatabaseUserUtil.setLevel(memberId, adjustedLevel);
+      new DatabaseUserUtil(memberId).setGuildLevel(guildId, adjustedLevel);
 
       logger.info(String.format("[%s] Adjusted %s's XP by %s. Now %s XP. (Level %s)",
           event.getGuild(),

--- a/src/com/somefriggnidiot/discord/commands/functionalities/xp/moderation/ClearXpCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/functionalities/xp/moderation/ClearXpCommand.java
@@ -29,11 +29,12 @@ public class ClearXpCommand extends Command {
    @Override
    protected void execute(CommandEvent event) {
       Member member = event.getMessage().getMentionedMembers().get(0);
+      Long guildId = event.getGuild().getIdLong();
 
-      DatabaseUserUtil.setXp(event.getGuild().getIdLong(), member.getUser().getIdLong(), 0);
-      DatabaseUserUtil.setLevel(member.getUser().getIdLong(), 0);
+      DatabaseUserUtil.setXp(guildId, member.getUser().getIdLong(), 0);
+      DatabaseUserUtil.getUser(member.getUser().getIdLong()).updateLevel(guildId, 0);
 
-      logger.info(String.format("[%s] Reset global XP for %s.",
+      logger.info(String.format("[%s] Reset guild XP for %s.",
           event.getGuild(),
           member.getEffectiveName()));
    }

--- a/src/com/somefriggnidiot/discord/commands/functionalities/xp/moderation/ToggleXpGainCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/functionalities/xp/moderation/ToggleXpGainCommand.java
@@ -5,6 +5,7 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.somefriggnidiot.discord.data_access.models.GuildInfo;
 import com.somefriggnidiot.discord.data_access.util.GuildInfoUtil;
 import com.somefriggnidiot.discord.events.MessageListener;
+import com.somefriggnidiot.discord.util.VoiceXpUtil;
 import net.dv8tion.jda.core.Permission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,11 +36,21 @@ public class ToggleXpGainCommand extends Command {
          GuildInfoUtil.setXpTracking(event.getGuild().getIdLong(), false);
          logger.info(String.format("[%s] Guild is no longer granting message xp.",
              event.getGuild()));
+
+         VoiceXpUtil.stopTimer(event.getGuild().getIdLong());
+         logger.info(String.format("[%s] Stopped voice XP timer.",
+             event.getGuild()));
+
          event.reply("XP tracking disabled.");
       } else {
          GuildInfoUtil.setXpTracking(event.getGuild().getIdLong(), true);
          logger.info(String.format("[%s] Guild is now granting message xp.",
              event.getGuild()));
+
+         VoiceXpUtil.startTimer(event.getGuild().getIdLong());
+         logger.info(String.format("[%s] Started voice XP timer.",
+             event.getGuild()));
+
          event.reply("XP tracking enabled.");
       }
    }

--- a/src/com/somefriggnidiot/discord/commands/functionalities/xp/xpinfo/ShowXpCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/functionalities/xp/xpinfo/ShowXpCommand.java
@@ -52,7 +52,8 @@ public class ShowXpCommand extends Command {
          } catch (NumberFormatException e) {
             //Get self XP
             dbu = DatabaseUserUtil.getUser(event.getAuthor().getIdLong());
-            level = dbu.getLevel() == null ? "0" : dbu.getLevel().toString();
+            level = dbu.getLevelMap().get(event.getGuild().getIdLong()) == null ? "0" :
+                dbu.getLevelMap().get(event.getGuild().getIdLong()).toString();
             xp = dbu.getXpMap().get(event.getGuild().getIdLong()) == null ? 0 : dbu.getXpMap().get
                 (event.getGuild().getIdLong());
             nextXp = XpUtil.getXpThresholdForLevel(Integer.valueOf(level)+1);
@@ -74,7 +75,8 @@ public class ShowXpCommand extends Command {
       } else {
          User user = event.getMessage().getMentionedUsers().get(0);
          dbu = DatabaseUserUtil.getUser(user.getIdLong());
-         level = dbu.getLevel() == null ? "0" : dbu.getLevel().toString();
+         level = dbu.getLevelMap().get(event.getGuild().getIdLong()) == null ? "0" :
+             dbu.getLevelMap().get(event.getGuild().getIdLong()).toString();
          xp = dbu.getXpMap().get(event.getGuild().getIdLong()) == null ? 0 : dbu.getXpMap().get
              (event.getGuild().getIdLong());
          nextXp = XpUtil.getXpThresholdForLevel(Integer.valueOf(level)+1);

--- a/src/com/somefriggnidiot/discord/commands/functionalities/xp/xpinfo/XpLeaderboardCommand.java
+++ b/src/com/somefriggnidiot/discord/commands/functionalities/xp/xpinfo/XpLeaderboardCommand.java
@@ -5,6 +5,7 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.somefriggnidiot.discord.data_access.models.DatabaseUser;
 import com.somefriggnidiot.discord.data_access.util.DatabaseUserUtil;
 import com.somefriggnidiot.discord.util.HighscoreObject;
+import com.somefriggnidiot.discord.util.XpUtil;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -78,7 +79,7 @@ public class XpLeaderboardCommand extends Command {
             top += String.format("**%s. %s** - Level %s - %s XP\n",
                 rank++,
                 guild.getMemberById(sortedScores.get(index).getUser().getId()).getEffectiveName(),
-                sortedScores.get(index).getUser().getLevel(),
+                XpUtil.getLevelForXp(sortedScores.get(index).getXp()),
                 new DecimalFormat("###,###").format(sortedScores.get(index).getXp()));
             index++;
          } catch (IndexOutOfBoundsException e) {

--- a/src/com/somefriggnidiot/discord/core/Main.java
+++ b/src/com/somefriggnidiot/discord/core/Main.java
@@ -18,6 +18,7 @@ import com.somefriggnidiot.discord.commands.functionalities.raffle.DrawRaffleCom
 import com.somefriggnidiot.discord.commands.functionalities.raffle.EnterRaffleCommand;
 import com.somefriggnidiot.discord.commands.functionalities.raffle.ListRafflesCommand;
 import com.somefriggnidiot.discord.commands.functionalities.tokens.AdjustTokensCommand;
+import com.somefriggnidiot.discord.commands.functionalities.tokens.ResetAllTokensCommand;
 import com.somefriggnidiot.discord.commands.functionalities.xp.moderation.AdjustXpCommand;
 import com.somefriggnidiot.discord.commands.functionalities.xp.rolelevels.AddRoleLevelCommand;
 import com.somefriggnidiot.discord.commands.functionalities.xp.moderation.ClearXpCommand;
@@ -86,7 +87,8 @@ public class Main {
                  new ListRafflesCommand()
              )
              .addCommands( // Tokens
-                 new AdjustTokensCommand()
+                 new AdjustTokensCommand(),
+                 new ResetAllTokensCommand()
              )
              .addCommands( //XP - Moderation
                  new AdjustXpCommand(),

--- a/src/com/somefriggnidiot/discord/core/Main.java
+++ b/src/com/somefriggnidiot/discord/core/Main.java
@@ -31,16 +31,19 @@ import com.somefriggnidiot.discord.commands.moderation.GetWarningsCommand;
 import com.somefriggnidiot.discord.commands.moderation.RemoveAllUsersFromRoleCommand;
 import com.somefriggnidiot.discord.commands.moderation.SoftBanCommand;
 import com.somefriggnidiot.discord.commands.moderation.WarningCommand;
+import com.somefriggnidiot.discord.data_access.util.GuildInfoUtil;
 import com.somefriggnidiot.discord.events.GuildMemberListener;
 import com.somefriggnidiot.discord.events.GuildVoiceListener;
 import com.somefriggnidiot.discord.events.MessageListener;
 import com.somefriggnidiot.discord.events.UserUpdateGameListener;
+import com.somefriggnidiot.discord.util.VoiceXpUtil;
 import java.net.URL;
 import java.util.List;
 import javax.security.auth.login.LoginException;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.JDABuilder;
 import net.dv8tion.jda.core.entities.Game;
+import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Icon;
 import net.dv8tion.jda.core.entities.User;
 import org.slf4j.Logger;
@@ -145,6 +148,14 @@ public class Main {
              jda.getGuilds().size(),
              users,
              jda.getUsers().size() - users));
+
+         for (Guild guild : jda.getGuilds()) {
+            if (GuildInfoUtil.getGuildInfo(guild.getIdLong()).isGrantingMessageXp()) {
+               VoiceXpUtil.startTimer(guild.getIdLong());
+               logger.info(String.format("[%s] Started voice XP timer.",
+                   guild));
+            }
+         }
       } catch (LoginException e) {
          logger.error("Error logging in to Discord.", e);
       } catch (InterruptedException e2) {

--- a/src/com/somefriggnidiot/discord/data_access/models/DatabaseUser.java
+++ b/src/com/somefriggnidiot/discord/data_access/models/DatabaseUser.java
@@ -18,6 +18,7 @@ public class DatabaseUser {
    private List<String> warningIds;
    private Integer level;
    private HashMap<Long, Integer> xpMap;
+   private HashMap<Long, Integer> levelMap;
    private HashMap<Long, Integer> tokenMap;
    private Timestamp lastMessageDtTm;
 
@@ -26,6 +27,8 @@ public class DatabaseUser {
       this.karma = 0;
       this.level = 0;
       this.xpMap = new HashMap<>();
+      this.levelMap = new HashMap<>();
+      this.tokenMap = new HashMap<>();
    }
 
    public Long getId() {
@@ -87,6 +90,24 @@ public class DatabaseUser {
       return this;
    }
 
+   /**
+    * Fetches the map of a user's level for each guild.
+    * @return a HashMap where the guildId functions as the key and the user's level within that
+    * guild is the value.
+    */
+   public HashMap<Long, Integer> getLevelMap() {
+      return levelMap == null ? new HashMap<>() : levelMap;
+   }
+
+   public void setLevelMap(HashMap<Long, Integer> levelMap) {
+      this.levelMap = levelMap;
+   }
+
+   public Integer updateLevel(Long guildId, Integer newLevelValue) {
+      levelMap = levelMap == null ? new HashMap<>() : levelMap;
+      return levelMap.put(guildId, newLevelValue);
+   }
+
    public HashMap<Long, Integer> getTokenMap() {
       return tokenMap == null ? new HashMap<>() : tokenMap;
    }
@@ -115,19 +136,6 @@ public class DatabaseUser {
 
    public DatabaseUser withUpdatedDtTm(Timestamp updatedDtTm) {
       this.lastMessageDtTm = updatedDtTm;
-      return this;
-   }
-
-   public Integer getLevel() {
-      return level == null ? 0 : level;
-   }
-
-   public void setLevel(Integer level) {
-      this.level = level;
-   }
-
-   public DatabaseUser withLevel(Integer level) {
-      this.level = level;
       return this;
    }
 }

--- a/src/com/somefriggnidiot/discord/events/GuildMemberListener.java
+++ b/src/com/somefriggnidiot/discord/events/GuildMemberListener.java
@@ -8,7 +8,8 @@ import org.slf4j.LoggerFactory;
 public class GuildMemberListener extends ListenerAdapter {
 
    private final Logger logger = LoggerFactory.getLogger(MessageListener.class);
-   private final String[] bannedNames = new String[]{"bitch", "cunt", "whore", "fag", "slut"};
+   private final String[] bannedNames = new String[]{"bitch", "cunt", "whore", "fag", "slut",
+       "hitler", "fuck"};
 
    @Override
    public void onGuildMemberNickChange(GuildMemberNickChangeEvent event) {

--- a/src/com/somefriggnidiot/discord/events/UserUpdateGameListener.java
+++ b/src/com/somefriggnidiot/discord/events/UserUpdateGameListener.java
@@ -99,6 +99,7 @@ public class UserUpdateGameListener extends ListenerAdapter {
 
    private void handleSwap(UserUpdateGameEvent event, HashMap<String, String> gameMap,
        String oldGameName, String newGameName) {
+      //If both old and new are invalid, skip.
       if (!isValidGame(gameMap, oldGameName) && !isValidGame(gameMap, newGameName)) {
          return;
       }
@@ -109,11 +110,15 @@ public class UserUpdateGameListener extends ListenerAdapter {
          oldRole = event.getGuild().getRolesByName(oldGameName, false).get(0);
       } catch (IndexOutOfBoundsException e) {
          logger
-             .debug(String.format("[%s] Role not found for \"%s\"", event.getGuild(), oldGameName));
+             .debug(String.format("[%s] Previous game not present: \"%s\"",
+                 event.getGuild(),
+                 oldGameName));
       }
       if (oldRole == null) {
          logger
-             .warn(String.format("[%s] Role not found for \"%s\"", event.getGuild(), oldGameName));
+             .warn(String.format("[%s] Role not found for previous game: \"%s\"",
+                 event.getGuild(),
+                 oldGameName));
          return;
       } else {
          //Log it
@@ -127,7 +132,9 @@ public class UserUpdateGameListener extends ListenerAdapter {
             event.getGuild().getController().removeSingleRoleFromMember(event.getMember(), oldRole)
                 .queue();
          } catch (Exception e) {
-            logger.warn(String.format("[%s] Role not found for \"%s\"", event.getGuild(), oldRole));
+            logger.warn(String.format("[%s] Role not found for \"%s\"",
+                event.getGuild(),
+                oldRole));
          }
       }
 
@@ -136,17 +143,21 @@ public class UserUpdateGameListener extends ListenerAdapter {
          newRole = event.getGuild().getRolesByName(newGameName, false).get(0);
       } catch (IndexOutOfBoundsException e) {
          logger
-             .debug(String.format("[%s] Role not found for \"%s\"", event.getGuild(), newGameName));
+             .debug(String.format("[%s] New game not present: \"%s\"",
+                 event.getGuild(),
+                 newGameName));
       }
       if (newRole == null) {
          logger
-             .warn(String.format("[%s] Role not found for \"%s\"", event.getGuild(), newGameName));
+             .warn(String.format("[%s] Role not found for new game: \"%s\"",
+                 event.getGuild(),
+                 newGameName));
       } else {
          //Log it
-         logger.info(String.format("%s has started playing %s in %s.",
+         logger.info(String.format("[%s] %s has started playing %s.",
+             event.getGuild(),
              event.getMember().getEffectiveName(),
-             event.getNewGame().getName(),
-             event.getGuild().getName()));
+             event.getNewGame().getName()));
 
          //Assign role
          try {

--- a/src/com/somefriggnidiot/discord/util/MessageListenerUtil.java
+++ b/src/com/somefriggnidiot/discord/util/MessageListenerUtil.java
@@ -3,6 +3,7 @@ package com.somefriggnidiot.discord.util;
 import com.somefriggnidiot.discord.data_access.models.DatabaseUser;
 import com.somefriggnidiot.discord.data_access.util.DatabaseUserUtil;
 import com.somefriggnidiot.discord.events.MessageListener;
+import java.text.DecimalFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ThreadLocalRandom;
@@ -13,6 +14,7 @@ import org.slf4j.LoggerFactory;
 public class MessageListenerUtil {
 
    private static final Logger logger = LoggerFactory.getLogger(MessageListener.class);
+   private static final DecimalFormat df = new DecimalFormat("###,###");
 
    public static void handleXpGain(MessageReceivedEvent event) {
       if (event.getAuthor().isBot()) return;
@@ -24,7 +26,7 @@ public class MessageListenerUtil {
       Instant userLastMessageTime;
 
       if (XpUtil.tokenDropActivated()) {
-         XpUtil.handleTokenDrops(event.getGuild(), event.getAuthor(), 2);
+         XpUtil.handleTokenDrops(event.getGuild(), event.getAuthor(), 1);
       }
 
       if (dbu.getLastMessageDtTm() == null) {
@@ -51,14 +53,15 @@ public class MessageListenerUtil {
          logger.info(String.format("[%s] %s gained %s xp for messaging. They're now at %s xp.",
              event.getGuild(),
              event.getAuthor().getName(),
-             xpGain,
-             newXp));
+             df.format(xpGain),
+             df.format(newXp)));
 
          if (XpUtil.checkForLevelUp(event.getGuild(), event.getAuthor(), newXp) > 0) {
             logger.info(String.format("[%s] %s has leveled up! Now level %s!",
                 event.getGuild(),
                 event.getAuthor().getName(),
-                dbu.getLevel()));
+                dbu.getLevelMap().get(event.getGuild().getIdLong()) == null ? "0" :
+                    dbu.getLevelMap().get(event.getGuild().getIdLong()).toString()));
          }
       }
    }

--- a/src/com/somefriggnidiot/discord/util/XpUtil.java
+++ b/src/com/somefriggnidiot/discord/util/XpUtil.java
@@ -38,10 +38,12 @@ public class XpUtil {
              (newLevel - currentLevel)
          );
 
+         String effectiveName = guild.getMember(user).getEffectiveName();
+
          EmbedBuilder eb = new EmbedBuilder()
              .setColor(Color.CYAN)
              .setThumbnail(user.getAvatarUrl())
-             .setTitle(String.format("%s has leveled up!", user.getName()))
+             .setTitle(String.format("%s has leveled up!", effectiveName))
              .addField("Current Level", newLevelString, true)
              .addField("Progress to Next Level",
                  newXp + " / " + getXpThresholdForLevel(newLevel+1)
@@ -153,7 +155,7 @@ public class XpUtil {
     * @return whether or not a token drop has been activated.
     */
    public static Boolean tokenDropActivated() {
-      return ThreadLocalRandom.current().nextInt(50) == 1;
+      return ThreadLocalRandom.current().nextInt(150) == 1;
    }
 
    /**

--- a/src/com/somefriggnidiot/discord/util/XpUtil.java
+++ b/src/com/somefriggnidiot/discord/util/XpUtil.java
@@ -25,13 +25,12 @@ public class XpUtil {
 
    public static Integer checkForLevelUp(Guild guild, User user, Integer newXp) {
       Long userId = user.getIdLong();
-      Integer currentLevel = DatabaseUserUtil.getUser(userId).getLevel() == null ? 0 :
-          DatabaseUserUtil.getUser(userId).getLevel();
+      Integer currentLevel = new DatabaseUserUtil(userId).getGuildLevel(guild.getIdLong());
       Integer xpThreshold = getXpThresholdForLevel(currentLevel+1);
       Integer newLevel = currentLevel;
 
       if (newXp > xpThreshold) {
-         newLevel = DatabaseUserUtil.setLevel(userId, getLevelForXp(newXp));
+         newLevel = new DatabaseUserUtil(userId).setGuildLevel(guild.getIdLong(), getLevelForXp(newXp));
          String newLevelString = String.format("**%s**  (%s%s)",
              newLevel.toString(),
              (newLevel - currentLevel)>=1 ? "+" : "",
@@ -66,7 +65,7 @@ public class XpUtil {
              .sendMessage(eb.build()).queue();
 
       } else if (newXp < getXpThresholdForLevel(currentLevel)) {
-         newLevel = DatabaseUserUtil.setLevel(userId, getLevelForXp(newXp));
+         newLevel = new DatabaseUserUtil(userId).setGuildLevel(guild.getIdLong(), getLevelForXp(newXp));
          logger.info(String.format("[%s] Demoted %s to level %s.",
              guild,
              user.getName(),
@@ -84,7 +83,7 @@ public class XpUtil {
 
       if (gi.getLevelRolesActive() || gi.getRoleLevelMappings().size() > 0) {
          HashMap<Long, Integer> roleLevelIds = gi.getRoleLevelMappings();
-         Integer userLevel = DatabaseUserUtil.getUser(userId).getLevel();
+         Integer userLevel = new DatabaseUserUtil(userId).getLevel(guild.getIdLong());
          List<Long> applicableRoleIds = roleLevelIds.keySet().stream()
              .filter(e -> roleLevelIds.get(e) <= userLevel)
              .collect(Collectors.toList());
@@ -126,7 +125,7 @@ public class XpUtil {
       Integer threshold = 0;
 
       for (int i=0; i<level; i++) {
-         threshold += 5*(i*i) + 50*(i) + 100;
+         threshold += 5*(i*i) + 100*(i) + 250;
       }
 
       return threshold;
@@ -155,7 +154,7 @@ public class XpUtil {
     * @return whether or not a token drop has been activated.
     */
    public static Boolean tokenDropActivated() {
-      return ThreadLocalRandom.current().nextInt(150) == 1;
+      return ThreadLocalRandom.current().nextInt(201) == 1;
    }
 
    /**


### PR DESCRIPTION
- Refactored voice tracking to prevent multiple loops per person. (Fixing bug that allowed users to gain massive amounts of XP by quickly leaving and rejoining voice channels.)
- Refactored levels to be specific to guild. (Fixing bug that caused incorrect level to display across guilds shared by both user and bot.)
- Refactored level displays to always be based off of user XP.
- Refactored some logging messages to be more distinct/descriptive.
- Added command to reset all tokens for all users.